### PR TITLE
Added start in insert mode as document in Vintage

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -26,4 +26,7 @@
 
 	// If true, some commands will take the current indentation level into account.
 	"vintageous_autoindent": true,
+
+	// If true, all opened tabs will start in insert mode
+	"vintageous_start_in_insert_mode": false
 }

--- a/state.py
+++ b/state.py
@@ -70,6 +70,12 @@ def _init_vintageous(view):
     state = VintageState(view)
 
     # Non-standard user setting.
+    start_in_insert = state.settings.view['vintageous_start_in_insert_mode']
+    if start_in_insert:
+        state.enter_insert_mode()
+        return
+
+    # Non-standard user setting.
     reset = state.settings.view['vintageous_reset_mode_when_switching_tabs']
     # XXX: If the view was already in normal mode, we still need to run the init code. I believe
     # this is due to Sublime Text (intentionally) not serializing the inverted caret state and


### PR DESCRIPTION
#47 introduced start in normal mode, but some sublime users prefer to start in insert mode (#216), a simple setting would appeal to both kinds of users.

http://www.sublimetext.com/docs/3/vintage.html also documents a similar setting (but reversed).
