### PR TITLE
Filter_thru_shell - Fixed bytestring error and implemented more vim-like behavior.

### DIFF
--- a/ex/plat/linux.py
+++ b/ex/plat/linux.py
@@ -24,4 +24,4 @@ def filter_region(view, text, command):
     shell = shell or os.path.expandvars("$SHELL")
     p = subprocess.Popen([shell, '-c', 'echo "%s" | %s' % (text, command)],
                          stdout=subprocess.PIPE)
-    return p.communicate()[0][:-1]
+    return p.communicate()[0][:-1].decode('utf-8')

--- a/ex/shell.py
+++ b/ex/shell.py
@@ -4,7 +4,6 @@ import Vintageous.ex.plat as plat
 import Vintageous.ex.plat.linux
 import Vintageous.ex.plat.osx
 import Vintageous.ex.plat.windows
-from Vintageous.vi.constants import MODE_NORMAL
 
 
 def run_and_wait(view, cmd):
@@ -47,10 +46,9 @@ def filter_thru_shell(view, edit, regions, cmd):
     for r in regions:
         r_shifted = sublime.Region(r.begin() + accumulated_delta, r.end() + accumulated_delta)
         rv = filter_func(view, view.substr(r_shifted), cmd)
-        rv_string = rv.decode("utf8")
-        view.replace(edit, r_shifted, rv_string)
+        view.replace(edit, r_shifted, rv)
         new_points.append(r_shifted.a)
-        accumulated_delta += len(rv_string) - r_shifted.size()
+        accumulated_delta += len(rv) - r_shifted.size()
 
     # Switch to normal mode and move cursor(s) to beginning of replacement(s)
     view.run_command('vi_enter_normal_mode')

--- a/test_runner.py
+++ b/test_runner.py
@@ -75,6 +75,7 @@ TESTS_CMDS_ACTION_VI_BIG_J = 'Vintageous.tests.commands.test__vi_big_j'
 TESTS_EX_CMDS_COPY = 'Vintageous.tests.ex.test_copy'
 TESTS_EX_CMDS_MOVE = 'Vintageous.tests.ex.test_move'
 TESTS_EX_CMDS_DELETE = 'Vintageous.tests.ex.test_delete'
+TESTS_EX_CMDS_SHELL_OUT = 'Vintageous.tests.ex.test_shell_out'
 
 TESTS_UNITS_WORD = 'Vintageous.tests.vi.test_word'
 TESTS_UNITS_BIG_WORD = 'Vintageous.tests.vi.test_big_word'
@@ -115,6 +116,7 @@ TESTS_EX_CMDS = [
     TESTS_EX_CMDS_COPY,
     TESTS_EX_CMDS_MOVE,
     TESTS_EX_CMDS_DELETE,
+    TESTS_EX_CMDS_SHELL_OUT,
 ]
 
 TESTS_UNITS_ALL = [TESTS_UNITS_WORD,

--- a/tests/ex/test_shell_out.py
+++ b/tests/ex/test_shell_out.py
@@ -1,0 +1,99 @@
+import unittest
+
+from Vintageous.tests import set_text
+from Vintageous.tests import add_sel
+from Vintageous.tests import get_sel
+from Vintageous.tests import BufferTest
+
+import Vintageous.ex.plat as plat
+from Vintageous.ex.ex_command_parser import parse_command
+
+class Test_ex_shell_out_no_input(BufferTest):
+    def testCommandOutput(self):
+        test_string = 'Testing!'
+        test_command_line = ':!echo "' + test_string + '"'
+        ex_cmd = parse_command(test_command_line)
+        ex_cmd.args['line_range'] = ex_cmd.line_range
+
+        output_panel = self.view.window().get_output_panel('vi_out')
+        self.view.run_command(ex_cmd.command, ex_cmd.args)
+
+        actual = output_panel.substr(self.R(0, output_panel.size()))
+        expected = test_string + '\n'
+        self.assertEqual(expected, actual)
+
+class Test_ex_shell_out_filter_through_shell(BufferTest):
+    @staticmethod
+    def getWordCountCommand():
+        if plat.HOST_PLATFORM == plat.WINDOWS:
+            return None
+        else:
+            return 'wc -w'
+
+    def testSimpleFilterThroughShell(self):
+        word_count_command = self.__class__.getWordCountCommand()
+        # TODO implement test for Windows.
+        if not word_count_command:
+            return True
+        set_text(self.view, 'One two three four\nfive six seven eight\nnine ten.')
+        add_sel(self.view, self.R((0, 8), (1, 3)))
+
+        test_command_line = ":'<,'>!" + word_count_command
+        ex_cmd = parse_command(test_command_line)
+        ex_cmd.args['line_range'] = ex_cmd.line_range
+
+        self.view.run_command(ex_cmd.command, ex_cmd.args)
+
+        actual = self.view.substr(self.R(0, self.view.size()))
+        expected = '8\nnine ten.'
+        self.assertEqual(expected, actual)
+        self.assertEqual(1, len(self.view.sel()))
+        cursor = get_sel(self.view, 0)
+        self.assertEqual(cursor.begin(), cursor.end())
+        self.assertEqual(self.view.text_point(0, 0), cursor.begin())
+
+    def testMultipleFilterThroughShell(self):
+        word_count_command = self.__class__.getWordCountCommand()
+        # TODO implement test for Windows.
+        if not word_count_command:
+            return True
+        set_text(self.view, '''Beginning of test!
+One two three four
+five six seven eight
+nine ten.
+These two lines shouldn't be replaced
+by the command.
+One two three four five six
+seven eight nine
+ten
+eleven
+twelve
+End of Test!
+''')
+        # Two selections touching all numeric word lines.
+        add_sel(self.view, self.R((1, 11), (3, 1)))
+        add_sel(self.view, self.R((6, 1), (10, 5)))
+
+        test_command_line = ":'<,'>!" + word_count_command
+        ex_cmd = parse_command(test_command_line)
+        ex_cmd.args['line_range'] = ex_cmd.line_range
+
+        self.view.run_command(ex_cmd.command, ex_cmd.args)
+
+        actual = self.view.substr(self.R(0, self.view.size()))
+        expected = '''Beginning of test!
+10
+These two lines shouldn't be replaced
+by the command.
+12
+End of Test!
+'''
+        self.assertEqual(expected, actual)
+        self.assertEqual(2, len(self.view.sel()))
+        cursor0 = get_sel(self.view, 0)
+        cursor1 = get_sel(self.view, 1)
+        self.assertEqual(cursor0.begin(), cursor0.end())
+        self.assertEqual(cursor1.begin(), cursor1.end())
+        self.assertEqual(self.view.text_point(1, 0), cursor0.begin())
+        self.assertEqual(self.view.text_point(4, 0), cursor1.begin())
+


### PR DESCRIPTION
Fixed error passing a bytestring into view.replace so that filtering through shell works ":'<,'>!<command>".
Implemented vim-like behavior of deselecting the replacement text and placing the cursor at its start (working for multiple selections).
