### PR TITLE
Move to first non whitespace for d, dd and cc actions

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -1100,7 +1100,8 @@ class _vi_cc_action(sublime_plugin.TextCommand):
             if mode == _MODE_INTERNAL_NORMAL:
                 begin = self.view.text_point(self.view.rowcol(s.b)[0], 0)
                 view.erase(edit, s)
-                return sublime.Region(begin)
+                pt = utils.next_non_white_space_char(view, begin)
+                return sublime.Region(pt)
             return s
 
         def ff(view, s):
@@ -1155,7 +1156,9 @@ class _vi_dd_action(sublime_plugin.TextCommand):
         row = [self.view.rowcol(s.begin())[0] for s in self.view.sel()][0]
         regions_transformer_reversed(self.view, f)
         self.view.sel().clear()
-        self.view.sel().add(sublime.Region(self.view.text_point(row, 0)))
+
+        pt = utils.next_non_white_space_char(self.view, self.view.text_point(row, 0))
+        self.view.sel().add(sublime.Region(pt))
 
 
 class _vi_big_s_action(sublime_plugin.TextCommand):

--- a/transformers.py
+++ b/transformers.py
@@ -37,7 +37,7 @@ class _vi_d_post_action(sublime_plugin.TextCommand):
         def f(view, s):
             if is_at_eol(self.view, s) and not self.view.line(s.b).empty():
                 s = back_one_char(s)
-            # s = next_non_white_space_char(self.view, s.b)
+            s = next_non_white_space_char(self.view, s.b)
             return s
 
         regions_transformer(self.view, f)


### PR DESCRIPTION
Mirros behavior of Vim. Works for me, but did uncomment a line that was presumably commented for a good reason.
