### PR TITLE
Fixed yanking to the + register.

### DIFF
--- a/tests/vi/test_registers.py
+++ b/tests/vi/test_registers.py
@@ -192,6 +192,10 @@ class TestCaseRegisters(unittest.TestCase):
         self.assertEqual(self.regs.get(registers.REG_SYS_CLIPBOARD_1), ['foo'])
         self.assertEqual(self.regs.get(registers.REG_SYS_CLIPBOARD_2), ['foo'])
 
+        self.regs.set(registers.REG_SYS_CLIPBOARD_2, ['bar'])
+        self.assertEqual(self.regs.get(registers.REG_SYS_CLIPBOARD_1), ['bar'])
+        self.assertEqual(self.regs.get(registers.REG_SYS_CLIPBOARD_2), ['bar'])
+
     def testGetSysClipboardAlwaysIfRequested(self):
         self.regs.settings.view['vintageous_use_sys_clipboard'] = True
         sublime.set_clipboard('foo')

--- a/vi/registers.py
+++ b/vi/registers.py
@@ -114,7 +114,7 @@ class Registers(object):
         # Special registers and invalid registers won't be set.
         if (not (name.isalpha() or name.isdigit() or
                  name.isupper() or name == REG_UNNAMED or
-                 name == REG_SYS_CLIPBOARD_1 or
+                 name in REG_SYS_CLIPBOARD_ALL or
                  name == REG_EXPRESSION or
                  name == REG_SMALL_DELETE)):
                     # Vim fails silently.


### PR DESCRIPTION
Currently, `"+y` doesn't work but `"*y` does. This PR fixes the issue.
