### PR TITLE
Fix #639 big E to work correctly with c/d and visual mode

### DIFF
--- a/tests/commands/test__vi_big_e.py
+++ b/tests/commands/test__vi_big_e.py
@@ -1,0 +1,28 @@
+from collections import namedtuple
+
+from Vintageous.tests import ViewTest
+from Vintageous.vi.utils import modes
+
+test_data = namedtuple('test_data', 'text startRegion mode expectedRegion msg')
+
+ALL_CASES = (
+	test_data('01. 4',  (1, 1), modes.NORMAL,          (2, 2), 'Normal'),
+	test_data('012 4',  (1, 1), modes.INTERNAL_NORMAL, (1, 3), 'Internal Normal'),
+	test_data('0ab3 5', (1, 3), modes.VISUAL,          (1, 4), 'Visual Forward'),
+	test_data('0b2 a5', (5, 1), modes.VISUAL,          (5, 2), 'Visual Reverse no crossover'),
+	test_data('0ba3 5', (3, 1), modes.VISUAL,          (2, 4), 'Visual Reverse crossover'),
+)
+
+class Test_vi_big_e(ViewTest):
+	def runTests(self, data):
+		for (i, data) in enumerate(data):
+			self.write(data.text)
+			self.clear_sel()
+			self.add_sel(self.R(*data.startRegion))
+			self.view.run_command('_vi_big_e', {'mode': data.mode, 'count': 1})
+			self.assert_equal_regions(self.R(*data.expectedRegion), self.first_sel(),
+				"Failed on index {} {} : Text:\"{}\" Region:{}"
+					.format(i, data.msg, data.text, data.startRegion))
+
+	def testAllCases(self):
+		self.runTests(ALL_CASES)

--- a/xmotions.py
+++ b/xmotions.py
@@ -1771,21 +1771,36 @@ class _vi_big_n(ViMotionCommand):
 class _vi_big_e(ViMotionCommand):
     def run(self, mode=None, count=1):
         def do_move(view, s):
+            b = s.b
+            if s.a < s.b:
+                b = s.b - 1
+
+            pt = units.word_ends(view, b, count=count, big=True)
+
             if mode == modes.NORMAL:
-                pt = units.word_ends(view, s.b, count=count, big=True)
                 return sublime.Region(pt - 1)
 
             elif mode == modes.INTERNAL_NORMAL:
-                pt = units.word_ends(view, s.b, count=count, big=True)
-                return sublime.Region(pt - 1)
+                return sublime.Region(s.a, pt)
 
-            elif mode in (modes.VISUAL, modes.VISUAL_BLOCK):
-                pt = units.word_ends(view, s.b, count=count, big=True)
+            elif mode == modes.VISUAL:
+                start = s.a
+                if s.b < s.a:
+                    start = s.a - 1
+                end = pt - 1
+                if start <= end:
+                    return sublime.Region(start, end + 1)
+                else:
+                    return sublime.Region(start + 1, end)
+
+            # Untested
+            elif mode == modes.VISUAL_BLOCK:
                 if s.a > s.b:
                     if pt > s.a:
                         return sublime.Region(s.a - 1, pt)
                     return sublime.Region(s.a, pt - 1)
                 return sublime.Region(s.a, pt)
+
             return s
 
         regions_transformer(self.view, do_move)


### PR DESCRIPTION
Fixes #639, where cE and dE deletes a single character near the end instead of a range of characters. Also fixes visual E when selecting a left-to-right region and the cursor is under the 2nd last character of a word.
