### PR TITLE
find_paragraph_text_object(): modified to be more faithful to Vim

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -84,6 +84,12 @@ def make_region(view, a, b=None):
         return sublime.Region(a)
 
 
+def region2rowcols(view, reg):
+    '''Takes a view and a region. Returns a pair of row-col tuples
+    corresponding to the region's start and end points.'''
+    points = (reg.begin(), reg.end())
+    return list(map(view.rowcol, points))
+
 def set_text(view, text):
     view.run_command('__vi_tests_write_buffer', {'text': text})
 

--- a/vi/text_objects.py
+++ b/vi/text_objects.py
@@ -426,12 +426,10 @@ def find_paragraph_text_object(view, s, inclusive=True, count=1):
     return sublime.Region(begin, end)
 
 def find_inner_paragraph(view, initial_loc):
-    '''
-    Takes a location, as an integer. Returns a (begin, end) tuple of ints for
+    '''Takes a location, as an integer. Returns a (begin, end) tuple of ints for
     the Vim inner paragraph corresponding to that location. An inner paragraph
     consists of a set of contiguous lines all having the same whitespace status
-    (a line either consists entirely of whitespace characters or it does not).
-    '''
+    (a line either consists entirely of whitespace characters or it does not).'''
     # Determine whether the initial point lies in an all-whitespace line.
     is_whitespace = lambda region: len(view.substr(region).strip()) == 0
     iws = is_whitespace(view.line(initial_loc))


### PR DESCRIPTION
These changes address to the following issues: https://github.com/guillermooo/Vintageous/issues/675.

A few notes:

-- When I cloned, the test suite had 7 failing tests (wonder if I've set up my dev environment incorrectly?). After these changes, the same 7 failures are occurring.

-- I am willing to help by adding some more tests related to paragraph text objects, but before doing so I wanted to get a sanity check on the code I've got so far. Suggestions welcome.

-- My suspicion is that find_inner_paragraph() could be simpler if I knew my way around the sublime module better. Does sublime provide an easier way to identify regions of lines having the same whitespace status? CLASS_EMPTY_LINE doesn't appear to help, because it's too strict.
