### PR TITLE
Fix command definition collision between hat '^' and underscore '_'

### DIFF
--- a/vi/cmd_defs.py
+++ b/vi/cmd_defs.py
@@ -2884,9 +2884,9 @@ class ViMoveToBol(ViMotionDef):
 
 
 @keys.assign(seq=seqs.UNDERSCORE, modes=_MODES_MOTION)
-class ViMoveToBol(ViMotionDef):
+class ViMoveToSoftBol(ViMotionDef):
     """
-    Vim: `^`
+    Vim: `_`
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fixes #677

Both '^' and '_' were using the same class name "ViMoveToBol"
