### PR TITLE
Added ability to run individual test files, using TestLoader glob pattern

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -86,8 +86,11 @@ class RunVintageousTests(sublime_plugin.WindowCommand):
 
     def run(self, **kwargs):
         with self.chdir(kwargs.get('working_dir')):
+            # If kwargs['loader_pattern'] is supplied, only a subset of the
+            # tests will be discovered.
             p = os.path.join(os.getcwd(), 'tests')
-            suite = unittest.TestLoader().discover(p)
+            patt = kwargs.get('loader_pattern', 'test*.py',)
+            suite = unittest.TestLoader().discover(p, pattern=patt)
 
             file_regex = r'^\s*File\s*"([^.].*?)",\s*line\s*(\d+),.*$'
             display = OutputPanel('vintageous.tests', file_regex=file_regex)


### PR DESCRIPTION
Just a quick-and-dirty approach, but maybe that's enough for now. Example usage:

```
window.run_command('run_vintageous_tests', {'working_dir': '/Users/mhindman/proj/Vintageous', 'loader_pattern': 'test_word*reverse.py'})
```

Feel free to change the name of the key.
