### PR TITLE
fix #656: do not init on_load and on_new

### DIFF
--- a/xsupport.py
+++ b/xsupport.py
@@ -98,25 +98,6 @@ class ViFocusRestorerEvent(sublime_plugin.EventListener):
             # Switching back from another application. Ignore.
             pass
 
-    def on_new(self, view):
-        # Without this, on OS X Vintageous might not initialize correctly if
-        # the user leaves the application in a windowless state and then
-        # creates a new buffer.
-        if sublime.platform() == 'osx':
-            _init_vintageous(view)
-
-    def on_load(self, view):
-        # Without this, on OS X Vintageous might not initialize correctly if
-        # the user leaves the application in a windowless state and then
-        # creates a new buffer.
-        if sublime.platform() == 'osx':
-            try:
-                _init_vintageous(view)
-            except AttributeError:
-                _logger().error(
-                    '[VintageStateTracker] .settings() missing during .on_load() for {0}'
-                        .format(view.file_name()))
-
     def on_deactivated(self, view):
         self.timer = threading.Timer(0.25, self.action)
         self.timer.start()


### PR DESCRIPTION
Large files were causing Goto Anything to fail and throw errors
when using Vintageous. Deleting the on_load and on_new event
handlers (which were only doing anything on OSX) seems to fix the
issue. I can't remember exactly why they were added in the first
place, but I think, without them, Vintageous wouldn't automatically enter
normal mode when ST was coming from a windoless state in OSX.

In my brief testing, the change doesn't seem to cause any
regressions.
