### PR TITLE
Scroll to center of view when jumping to a marker outside of view region

### DIFF
--- a/xactions.py
+++ b/xactions.py
@@ -1213,6 +1213,9 @@ class _vi_quote(ViTextCommandBase):
 
         regions_transformer(self.view, f)
 
+        if not self.view.visible_region().intersects(address):
+            self.view.show_at_center(address)
+
 
 class _vi_backtick(ViTextCommandBase):
     def run(self, edit, count=1, mode=None, character=None):


### PR DESCRIPTION
Hi Guillermo, this small commit will make the view scroll to the center when the mark address is outside the current view's visible region. I felt this interaction is more similar to how vim deals with marks in command mode. I personally had trouble finding a good way to test this, so let me know if you have any ideas or improvements in general. 
