### PR TITLE
fixes #719 - improve cc with empty lines

### DIFF
--- a/tests/commands/test__vi_cc.py
+++ b/tests/commands/test__vi_cc.py
@@ -20,10 +20,6 @@ test_data = namedtuple('test_data', 'cmd initial_text regions cmd_params expecte
 region_data = namedtuple('region_data', 'regions')
 
 TESTS_INTERNAL_NORMAL = (
-    # MOTION
-    test_data(cmd='_vi_cc_motion', initial_text='foo bar\nfoo bar\nfoo bar\n', regions=[[(1, 2), (1, 2)]], cmd_params={'mode': modes.INTERNAL_NORMAL},
-              expected=region_data([(1, 0), (1, 7)]), actual_func=first_sel_wrapper, msg='selects whole line'),
-
     # OPERATOR
     test_data(cmd='_vi_cc_action', initial_text='foo bar\nfoo bar\nfoo bar\n',      regions=[[(1, 0), (1, 0)]], cmd_params={'mode': modes.INTERNAL_NORMAL},
               expected='foo bar\n\nfoo bar\n', actual_func=get_text,  msg=''),
@@ -36,7 +32,7 @@ TESTS_INTERNAL_NORMAL = (
 TESTS = TESTS_INTERNAL_NORMAL
 
 
-class Test_vi_cc_motion(ViewTest):
+class Test_vi_cc_action(ViewTest):
     def testAll(self):
         for (i, data) in enumerate(TESTS):
             # TODO: Perhaps we should ensure that other state is reset too?

--- a/xactions.py
+++ b/xactions.py
@@ -913,7 +913,6 @@ class _vi_dd_action(ViTextCommandBase):
 
     def run(self, edit, mode=None, count=1):
         def f(view, s):
-            # We've made a selection with _vi_cc_motion just before this.
             if mode == modes.INTERNAL_NORMAL:
                 view.erase(edit, s)
                 if utils.row_at(self.view, s.a) != utils.row_at(self.view, self.view.size()):
@@ -954,23 +953,6 @@ class _vi_dd_motion(sublime_plugin.TextCommand):
         regions_transformer(self.view, f)
 
 
-class _vi_cc_motion(ViTextCommandBase):
-    def run(self, edit, mode=None, count=1):
-        def f(view, s):
-            if mode == modes.INTERNAL_NORMAL:
-                if view.line(s.b).empty():
-                    return s
-
-                end = view.text_point(utils.row_at(self.view, s.b) + (count - 1), 0)
-                begin = view.line(s.b).a
-                begin = utils.next_non_white_space_char(view, begin, white_space=' \t')
-                return sublime.Region(begin, view.line(end).b)
-
-            return s
-
-        regions_transformer(self.view, f)
-
-
 class _vi_cc_action(ViTextCommandBase):
 
     _can_yank = True
@@ -978,16 +960,28 @@ class _vi_cc_action(ViTextCommandBase):
     _yanks_linewise = False
     _populates_small_delete_register = False
 
+    def motion(self, view, s, count, mode):
+        if mode == modes.INTERNAL_NORMAL:
+            if view.line(s.b).empty():
+                return s
+
+            end = view.text_point(utils.row_at(view, s.b) + (count - 1), 0)
+            begin = view.line(s.b).a
+            begin = utils.next_non_white_space_char(view, begin, white_space=' \t')
+            return sublime.Region(begin, view.line(end).b)
+
+        return s
+
     def run(self, edit, mode=None, count=1, register='"'):
-        self.save_sel()
-        self.view.run_command('_vi_cc_motion', {'mode': mode, 'count': count})
+        def f(view, s):
+            new_s = self.motion(view, s, count, mode)
+            if not new_s.empty():
+                state.registers.yank(self)
+                self.view.erase(edit, new_s)
+            return sublime.Region(new_s.a)
 
         state = self.state
-
-        if self.has_sel_changed():
-            state.registers.yank(self)
-            self.view.run_command('right_delete')
-
+        regions_transformer(self.view, f)
         self.enter_insert_mode(mode)
         self.set_xpos(state)
 
@@ -2482,7 +2476,6 @@ class _vi_gcc_action(ViTextCommandBase):
 
     def run(self, edit, mode=None, count=1):
         def f(view, s):
-            # We've made a selection with _vi_cc_motion just before this.
             if mode == modes.INTERNAL_NORMAL:
                 view.run_command('toggle_comment')
                 if utils.row_at(self.view, s.a) != utils.row_at(self.view, self.view.size()):


### PR DESCRIPTION
Ensure that we don't perform a delete when the cc motion has left
an empty region, i. e., when we're looking at a white-space only
line or an empty line.
