### PR TITLE
fix #817 - repeat data made command mode sluggish

### DIFF
--- a/state.py
+++ b/state.py
@@ -5,6 +5,7 @@ from collections import Counter
 from Vintageous import local_logger
 from Vintageous.vi import cmd_base
 from Vintageous.vi import cmd_defs
+from Vintageous.vi import settings
 from Vintageous.vi import utils
 from Vintageous.vi.contexts import KeyContext
 from Vintageous.vi.dot_file import DotFile
@@ -20,6 +21,7 @@ from Vintageous.vi.utils import is_ignored_but_command_mode
 from Vintageous.vi.utils import is_view
 from Vintageous.vi.utils import modes
 from Vintageous.vi.variables import Variables
+
 # !! Avoid error due to sublime_plugin.py:45 expectations.
 from Vintageous.plugins import plugins as user_plugins
 
@@ -415,6 +417,7 @@ class State(object):
         self.settings.vi['action_count'] = value
 
     @property
+    @settings.volatile
     def repeat_data(self):
         """
         Stores (type, cmd_name_or_key_seq, , mode) for '.' to use.
@@ -422,14 +425,14 @@ class State(object):
         `type` may be 'vi' or 'native'. `vi`-commands are executed via
         `ProcessNotation`, while `native`-commands are executed via .run_command().
         """
-        return self.settings.vi['repeat_data'] or None
+        return self.settings.vi.get('repeat_data') or None
 
     @repeat_data.setter
     def repeat_data(self, value):
         assert isinstance(value, tuple) or isinstance(value, list), 'bad call'
         assert len(value) == 4, 'bad call'
         self.logger.info("setting repeat data {0}".format(value))
-        self.settings.vi['repeat_data'] = value
+        self.settings.vi.set('repeat_data', value)
 
     @property
     def count(self):

--- a/xsupport.py
+++ b/xsupport.py
@@ -10,6 +10,7 @@ import sublime_plugin
 from Vintageous import local_logger
 from Vintageous.state import _init_vintageous
 from Vintageous.state import State
+from Vintageous.vi import settings
 from Vintageous.vi import cmd_defs
 from Vintageous.vi.dot_file import DotFile
 from Vintageous.vi.utils import modes
@@ -49,6 +50,9 @@ class VintageStateTracker(sublime_plugin.EventListener):
     def on_query_context(self, view, key, operator, operand, match_all):
         vintage_state = State(view)
         return vintage_state.context.check(key, operator, operand, match_all)
+
+    def on_close(self, view):
+        settings.destroy(view)
 
 
 class ViMouseTracker(sublime_plugin.EventListener):


### PR DESCRIPTION
Vintageous was keeping around repeat data in the view.Settings
object. When too much repeat data accummulated, command mode
started to become unresponsive. This was because Vintagous
accesses the view.Settings object many times for each command.

With this commit, repeat data is stored in a separate object
that Vintageous will only access if needed.

NOTE: Too many accesses to view.Settings may still be a design
      problem.

NOTE: This bug was especially frequent for users who perform
      many actions in insert mode, then exit insert mode.
      This revealed that actions performed in insert mode are
      always stored in the repeat data, even if they are motions
      and therefore should not. I believe (Guillermo) this is
      because it isn't possible to distinguish between native
      motions and actions simply by looking at the command
      data provided by Sublime Text.