### PR TITLE
fix #855 improve caret positioning after * motion

### DIFF
--- a/xmotions.py
+++ b/xmotions.py
@@ -1234,8 +1234,8 @@ class _vi_star(ViMotionCommand, ExactWordBufferSearchBase):
                     return sublime.Region(match.begin(), match.begin())
 
             elif mode == modes.NORMAL:
-                pt = utils.previous_white_space_char(view, s.b)
-                return sublime.Region(pt + 1)
+                pt = view.word(s.end()).begin()
+                return sublime.Region(pt)
 
             return s
 


### PR DESCRIPTION
Up until now, there was a bug where * would take you to the next
non-whitespace char after the previous whitespace char. This
happened only for non-matches.

For example:

    One.Two // Press * here
         ^

    One.Two // WRONG
    ^

    One.Two // CORRECT
        ^

The correct thing to do is to place the caret at the current word's
start.