### PR TITLE
Fix n/N motions after */#

### DIFF
--- a/state.py
+++ b/state.py
@@ -267,7 +267,7 @@ class State(object):
         previous command.
 
         Returns the name of the last character search command, namely:
-        'vi_slash', 'vi_question_mark'.
+        'vi_slash', 'vi_question_mark', 'vi_star', 'vi_octothorp'
         """
         name = self.settings.window['_vintageous_last_buffer_search_command']
         return name or 'vi_slash'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@ import sublime
 import unittest
 
 from Vintageous.state import State
-
+from Vintageous.vi.utils import modes
 
 class ViewTest(unittest.TestCase):
     """

--- a/tests/commands/test__vi_octothorp.py
+++ b/tests/commands/test__vi_octothorp.py
@@ -1,0 +1,72 @@
+from Vintageous.vi.utils import modes
+
+from Vintageous.tests import add_sel
+from Vintageous.tests import get_sel
+from Vintageous.tests import first_sel
+from Vintageous.tests import ViewTest
+
+
+class Test_vi_octothorp_InNormalMode(ViewTest):
+    def testSelectMatch(self):
+        self.write('abc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(0, 0), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7)])
+
+    def testSelectMatchMiddle(self):
+        self.write('abc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R(5, 5))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(0, 0), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7)])
+
+    def testSelectMatchEnd(self):
+        self.write('abc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R(6, 6))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(0, 0), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7)])
+
+    def testSelectRepeatMatch(self):
+        self.write('abc\nabc\nfoo\nabc\nbar')
+        self.clear_sel()
+        self.add_sel(self.R(12, 12))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(0, 0), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7), self.R(12, 15)])
+
+    def testSelectWrapMatch(self):
+        self.write('boo\nabc\nfoo\nabc\nbar')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(12, 12), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15)])
+
+    def testSelectNoPartialMatch(self):
+        self.write('boo\nabc\nabcxabc\nabc\nbar')
+        self.clear_sel()
+        self.add_sel(self.R(16, 16))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(16, 19)])
+
+    def testSelectNoMatch(self):
+        self.write('boo\nabc\nfoo\nabc\nbar')
+        self.clear_sel()
+        self.add_sel(self.R(9, 9))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(8, 8), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(8, 11)])

--- a/tests/commands/test__vi_repeat_search.py
+++ b/tests/commands/test__vi_repeat_search.py
@@ -1,0 +1,179 @@
+from Vintageous.vi.utils import modes
+
+from Vintageous.tests import add_sel
+from Vintageous.tests import get_sel
+from Vintageous.tests import first_sel
+from Vintageous.tests import ViewTest
+
+
+class Test_vi_repeat_star_InNormalMode(ViewTest):
+    def testRepeatForward(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(20, 20), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatForwardTwice(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatReverse(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': True})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatReverseTwice(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': True})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': True})
+        self.assertEqual(self.R(20, 20), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatForwardReverseTwiceForwardThrice(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        for i in range(0, 2):
+            self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': True})
+        for i in range(0, 3):
+            self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatNoPartial(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabcxend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15)])
+
+class Test_vi_repeat_octothorp_InNormalMode(ViewTest):
+    def testRepeatForward(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(12, 12), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatReverse(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': True})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatNoPartial(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabcxend')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_octothorp', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': True})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15)])
+
+class Test_vi_repeat_slash_InNormalMode(ViewTest):
+    def testRepeatForward(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(0, 0))
+
+        self.view.run_command('_vi_slash_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.state.last_buffer_search_command = 'vi_slash'
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(12, 12), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatReverse(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(0, 0))
+
+        self.view.run_command('_vi_slash_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.state.last_buffer_search_command = 'vi_slash'
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': True})
+        self.assertEqual(self.R(20, 20), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatPartial(self):
+        self.write('foo\nabc\nbar\nabcxmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(0, 0))
+
+        self.view.run_command('_vi_slash_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.state.last_buffer_search_command = 'vi_slash'
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(12, 12), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+class Test_vi_repeat_question_mark_InNormalMode(ViewTest):
+    def testRepeatForward(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(27, 27)) # TODO: 0, 0 should work since question mark should wrap around...
+
+        self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.state.last_buffer_search_command = 'vi_question_mark'
+        self.assertEqual(self.R(20, 20), first_sel(self.view))
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(12, 12), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatReverse(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(27, 27)) # TODO: 0, 0 should work since question mark should wrap around...
+
+        self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.state.last_buffer_search_command = 'vi_question_mark'
+        self.assertEqual(self.R(20, 20), first_sel(self.view))
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': True})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])
+
+    def testRepeatPartial(self):
+        self.write('foo\nabc\nbar\nabcxmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(27, 27)) # TODO: 0, 0 should work since question mark should wrap around...
+
+        self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.state.last_buffer_search_command = 'vi_question_mark'
+        self.assertEqual(self.R(20, 20), first_sel(self.view))
+        self.view.run_command('_vi_repeat_buffer_search', {'mode': modes.NORMAL, 'reverse': False})
+        self.assertEqual(self.R(12, 12), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15), self.R(20, 23)])

--- a/tests/commands/test__vi_repeat_search.py
+++ b/tests/commands/test__vi_repeat_search.py
@@ -145,7 +145,7 @@ class Test_vi_repeat_question_mark_InNormalMode(ViewTest):
     def testRepeatForward(self):
         self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
         self.clear_sel()
-        self.add_sel(self.R(27, 27)) # TODO: 0, 0 should work since question mark should wrap around...
+        self.add_sel(self.R(0, 0))
 
         self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
         self.state.last_buffer_search_command = 'vi_question_mark'
@@ -157,7 +157,7 @@ class Test_vi_repeat_question_mark_InNormalMode(ViewTest):
     def testRepeatReverse(self):
         self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
         self.clear_sel()
-        self.add_sel(self.R(27, 27)) # TODO: 0, 0 should work since question mark should wrap around...
+        self.add_sel(self.R(0, 0))
 
         self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
         self.state.last_buffer_search_command = 'vi_question_mark'
@@ -169,7 +169,7 @@ class Test_vi_repeat_question_mark_InNormalMode(ViewTest):
     def testRepeatPartial(self):
         self.write('foo\nabc\nbar\nabcxmoo\nabc\nend')
         self.clear_sel()
-        self.add_sel(self.R(27, 27)) # TODO: 0, 0 should work since question mark should wrap around...
+        self.add_sel(self.R(0, 0))
 
         self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
         self.state.last_buffer_search_command = 'vi_question_mark'

--- a/tests/commands/test__vi_search.py
+++ b/tests/commands/test__vi_search.py
@@ -1,0 +1,75 @@
+from Vintageous.vi.utils import modes
+
+from Vintageous.tests import add_sel
+from Vintageous.tests import get_sel
+from Vintageous.tests import first_sel
+from Vintageous.tests import ViewTest
+
+
+class Test_vi_slash_InNormalMode(ViewTest):
+    def testSearchBegin(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(0, 0))
+
+        self.view.run_command('_vi_slash_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+
+    def testSearchWrap(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(25, 25))
+
+        self.view.run_command('_vi_slash_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+
+    def testSearchWrapMidMatch(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(22, 22))
+
+        self.view.run_command('_vi_slash_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+
+    def testSearchWrapEnd(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+
+        self.clear_sel()
+        self.add_sel(self.R(27, 27))
+
+        self.view.run_command('_vi_slash_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+
+class Test_vi_question_mark_InNormalMode(ViewTest):
+    def testSearchWrapBegin(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(0, 0))
+
+        self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.assertEqual(self.R(20, 20), first_sel(self.view))
+
+    def testSearchWrap(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(25, 25))
+
+        self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.assertEqual(self.R(20, 20), first_sel(self.view))
+
+    def testSearchWrapMidMatch(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+        self.clear_sel()
+        self.add_sel(self.R(12, 12))
+
+        self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+
+    def testSearchEnd(self):
+        self.write('foo\nabc\nbar\nabc\nmoo\nabc\nend')
+
+        self.clear_sel()
+        self.add_sel(self.R(27, 27))
+
+        self.view.run_command('_vi_question_mark_impl', {'mode': modes.NORMAL, 'search_string': 'abc'})
+        self.assertEqual(self.R(20, 20), first_sel(self.view))

--- a/tests/commands/test__vi_star.py
+++ b/tests/commands/test__vi_star.py
@@ -1,0 +1,81 @@
+from Vintageous.vi.utils import modes
+
+from Vintageous.tests import add_sel
+from Vintageous.tests import get_sel
+from Vintageous.tests import first_sel
+from Vintageous.tests import ViewTest
+
+
+class Test_vi_star_InNormalMode(ViewTest):
+    def testSelectMatch(self):
+        self.write('abc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R(0, 0))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7)])
+
+    def testSelectMatchMiddle(self):
+        self.write('abc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R(1, 1))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7)])
+
+    def testSelectMatchEnd(self):
+        self.write('abc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R(2, 2))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7)])
+
+    def testSelectMatchEnd(self):
+        self.write('abc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R(2, 2))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7)])
+
+    def testSelectRepeatMatch(self):
+        self.write('abc\nabc\nfoo\nabc\nbar')
+        self.clear_sel()
+        self.add_sel(self.R(0, 0))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(12, 12), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(0, 3), self.R(4, 7), self.R(12, 15)])
+
+    def testSelectWrapMatch(self):
+        self.write('boo\nabc\nfoo\nabc\nbar')
+        self.clear_sel()
+        self.add_sel(self.R(12, 12))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(4, 4), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(12, 15)])
+
+    def testSelectNoPartialMatch(self):
+        self.write('boo\nabc\nabcxabc\nabc\nbar')
+        self.clear_sel()
+        self.add_sel(self.R(4, 4))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(16, 16), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(4, 7), self.R(16, 19)])
+
+    def testSelectNoMatch(self):
+        self.write('boo\nabc\nfoo\nabc\nbar')
+        self.clear_sel()
+        self.add_sel(self.R(9, 9))
+
+        self.view.run_command('_vi_star', {'mode': modes.NORMAL})
+        self.assertEqual(self.R(8, 8), first_sel(self.view))
+        self.assertEqual(self.view.get_regions('vi_search'), [self.R(8, 11)])

--- a/vi/cmd_defs.py
+++ b/vi/cmd_defs.py
@@ -3041,8 +3041,7 @@ class ViRepeatSearchForward(ViMotionDef):
         cmd['motion_args'] = {
             'mode': state.mode,
             'count': state.count,
-            'search_string': state.last_buffer_search,
-            'forward': state.last_buffer_search_command == 'vi_slash',
+            'reverse': False
             }
 
         return cmd
@@ -3065,8 +3064,7 @@ class ViRepeatSearchBackward(ViMotionDef):
         cmd['motion_args'] = {
             'mode': state.mode,
             'count': state.count,
-            'search_string': state.last_buffer_search,
-            'forward': not (state.last_buffer_search_command == 'vi_slash'),
+            'reverse': True
             }
         return cmd
 

--- a/vi/search.py
+++ b/vi/search.py
@@ -54,7 +54,7 @@ def reverse_find_wrapping(view, term, start, end, flags=0, times=1):
     for x in range(times):
         match = reverse_search(view, term, start, end, flags)
         # Start searching in the lower half of the buffer if we aren't doing it yet.
-        if not match and start < current_sel.b:
+        if not match and start <= current_sel.b:
             start = current_sel.b
             end = view.size()
             match = reverse_search(view, term, start, end, flags)


### PR DESCRIPTION
We need to remember the last search command for * and #, and use the command
or the reverse command on n/N.

This requires making _vi_star and _vi_octothorp act in both "grab the current
word and search" and "search for this word" modes.