### PR TITLE
fix reference to logger

### DIFF
--- a/state.py
+++ b/state.py
@@ -652,9 +652,8 @@ class State(object):
                         ((counter['\t'] * tab_size) - counter['\t']))
             except Exception as e:
                 print(e)
-                _logger.error(
+                _logger().error(
                     'Vintageous: Error when setting xpos. Defaulting to 0.')
-                _logger.show_error(e)
                 self.xpos = 0
                 return
             else:


### PR DESCRIPTION
A missing `()` causes an exception  at the exception handler. `show_error` method is removed because it's undefined for a logger and not used at other exception handlers at the same file. I'm not sure if I should also remove `print(e)`.