### PR TITLE
Fix builder.py (only packaging files in bin).

### DIFF
--- a/bin/builder.py
+++ b/bin/builder.py
@@ -39,6 +39,7 @@ def ifind_files(patterns):
 
 
 def build(target_dir="dist", release="dev"):
+    os.chdir(PROJECT_ROOT)
     manifest = get_manifest()
     name = manifest['name'] + '.sublime-package'
 


### PR DESCRIPTION
Previously the following commands will only packaging files in bin:

    cd bin
    bash build.sh

The problem is that although PROJECT_ROOT was current and manifest
was current, `glob.iglob` and `fnwatch` works against the current
directory, which was not PROJECT_ROOT.

This commit fix this.

--
 bin/builder.py | 1 +
  1 file changed, 1 insertion(+)