### PR TITLE
Fixing .vintageousrc not parsing omap, vmap; adding nmap

### DIFF
--- a/vi/dot_file.py
+++ b/vi/dot_file.py
@@ -23,7 +23,7 @@ class DotFile(object):
                 for line in f:
                     cmd, args = self.parse(line)
                     if cmd:
-                        _logger().info('[DotFile] running: {0} {1}'.format(cmd, args))
+                        print('[DotFile] running: {0} {1}'.format(cmd, args))
                         sublime.active_window().run_command(cmd, args)
         except FileNotFoundError:
             pass
@@ -31,20 +31,20 @@ class DotFile(object):
     def parse(self, line):
         try:
             _logger().info('[DotFile] parsing line: {0}'.format(line))
-            if line.startswith((':map ')):
-                line = line[1:]
+            line = line.lstrip(':')
+            if line.startswith(('map ')):
                 return ('ex_map', {'command_line': line.rstrip()})
 
-            if line.startswith((':omap ')):
-                line = line[len(':omap '):]
-                return ('ex_omap', {'cmd': line.rstrip()})
+            if line.startswith(('omap ')):
+                return ('ex_omap', {'command_line': line.rstrip()})
 
-            if line.startswith((':vmap ')):
-                line = line[len(':vmap '):]
-                return ('ex_vmap', {'cmd': line.rstrip()})
+            if line.startswith(('nmap ')):
+                return ('ex_nmap', {'command_line': line.rstrip()})
+            
+            if line.startswith(('vmap ')):
+                return ('ex_vmap', {'command_line': line.rstrip()})
 
-            if line.startswith((':let ')):
-                line = line[1:]
+            if line.startswith(('let ')):
                 return ('ex_let', {'command_line': line.strip()})
         except Exception:
             print('Vintageous: bad config in dotfile: "%s"' % line.rstrip())

--- a/vi/dot_file.py
+++ b/vi/dot_file.py
@@ -23,7 +23,7 @@ class DotFile(object):
                 for line in f:
                     cmd, args = self.parse(line)
                     if cmd:
-                        print('[DotFile] running: {0} {1}'.format(cmd, args))
+                        _logger().info('[DotFile] running: {0} {1}'.format(cmd, args))
                         sublime.active_window().run_command(cmd, args)
         except FileNotFoundError:
             pass


### PR DESCRIPTION
Hi Guillermo, I'm working on getting vintageous working with my rather esoteric vim preferences, and I run across some problems reading the .vintageousrc file. My PR change is pretty straightforward, it fixes some simple calling errors, and allows without a leading colon (to be consistent with actual .vimrc syntax).

I also might take a stab at implementing non-recursive (noremap) mappings; I'm currently kind of working around that limitation. I know the docs say that it doesn't support recursive mapping, but it looks the behavior is that most of the time it won't follow recursive maps, and thus behave very much like noremap, but some cases, like matching partials, it will.  If you have any suggestions or advice on this, let me know, I'm willing to put in some programming time because vintageous is pretty great :)