### PR TITLE
fixes #1000 - beter eol handling when redoing

### DIFF
--- a/tests/commands/test__vi_ctrl_r.py
+++ b/tests/commands/test__vi_ctrl_r.py
@@ -1,0 +1,42 @@
+import unittest
+
+from Vintageous.vi.utils import modes
+
+from Vintageous.state import State
+
+from Vintageous.tests import get_sel
+from Vintageous.tests import first_sel
+from Vintageous.tests import ViewTest
+
+
+# XXX: Am I using the best way to test this?
+class Test__vi_ctrl_r(ViewTest):
+    def testDoesNotLingerPastSoftEOL(self):
+        self.write('abc\nxxx\nabc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R((1, 0), (1, 0)))
+
+        self.view.run_command('_vi_dd', {'mode': modes.INTERNAL_NORMAL})
+        self.view.window().run_command('_vi_u')
+        self.view.window().run_command('_vi_ctrl_r') # passing mode is irrelevant
+
+        actual = self.view.substr(self.R(0, self.view.size()))
+        expected = 'abc\nabc\nabc'
+        self.assertEqual(expected, actual)
+        actual_sel = self.view.sel()[0]
+        self.assertEqual(self.R((1, 0), (1, 0)), actual_sel)
+
+    def testDoesNotLingerPastSoftEOL2(self):
+        self.write('abc\nxxx foo bar\nabc\nabc')
+        self.clear_sel()
+        self.add_sel(self.R((1, 8), (1, 8)))
+
+        self.view.run_command('_vi_big_d', {'mode': modes.INTERNAL_NORMAL})
+        self.view.window().run_command('_vi_u')
+        self.view.window().run_command('_vi_ctrl_r') # passing mode is irrelevant
+
+        actual = self.view.substr(self.R(0, self.view.size()))
+        expected = 'abc\nxxx foo \nabc\nabc'
+        self.assertEqual(expected, actual)
+        actual_sel = self.view.sel()[0]
+        self.assertEqual(self.R((1, 7), (1, 7)), actual_sel)

--- a/xactions.py
+++ b/xactions.py
@@ -187,6 +187,20 @@ class _vi_ctrl_r(ViWindowCommandBase):
         for i in range(count):
             self._view.run_command('redo')
 
+        self.correct_xpos()
+
+    # XXX: make this a global 'service'?
+    # XXX: In fact, this may indicate that the redone command is at fault. For example, it seems
+    # that de near EOL does not adjust xpos as it should. In summary: we need to revise commands
+    # and probably remove this here.
+    def correct_xpos(self):
+        def f(view, s):
+            if (view.substr(s.b) == '\n' and not view.line(s.b).empty()):
+                return R(s.b - 1)
+            return s
+
+        regions_transformer(self._view, f)
+
 
 class _vi_a(ViTextCommandBase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This is a quick fix, but it may suggest that some commands are not
handling xpos around EOL as they should. For example, 'de' near EOL
seems to be bugged.