### PR TITLE
Provide proper support for '^' and '$' anchors

### DIFF
--- a/ex_commands.py
+++ b/ex_commands.py
@@ -941,7 +941,7 @@ class ExSubstitute(sublime_plugin.TextCommand):
         ExSubstitute.last_replacement = replacement
         ExSubstitute.last_flags = flags
 
-        computed_flags = 0
+        computed_flags = re.MULTILINE
         computed_flags |= re.IGNORECASE if ('i' in flags) else 0
 
         try:


### PR DESCRIPTION
When performing ex-based substitution, '^' and '$' should match the
beginning of a line and the end of a line, respectively. However they
currently match only the beginning and end of the specified range.

Apply the re.MULTILINE flag to the compiled regular expression in order
to enable line-based matching with the '^' and '$' anchors.