### PR TITLE
Fix for P newline pasting

### DIFF
--- a/tests/commands/test_vi_big_p.py
+++ b/tests/commands/test_vi_big_p.py
@@ -30,6 +30,12 @@ TESTS = (
               in_register=['xxx\n'], params={'mode': modes.INTERNAL_NORMAL, 'count': 1},
               expected=('xxx\nabc', R(0, 0)), msg='failed in {0}'),
 
+    # INTERNAL NORMAL MODE - linewise issue#1015
+    test_data(content='a b c\nd e f',
+              regions=[[(1, 2), (1, 2)]],
+              in_register=['b c\n'], params={'mode': modes.INTERNAL_NORMAL, 'count': 1},
+              expected=('a b c\nd b c\ne f', R(8, 8)), msg='failed in {0}'),
+
     # VISUAL MODE
     test_data(content='abc',
               regions=[[(0, 0), (0, 3)]],
@@ -40,7 +46,7 @@ TESTS = (
     test_data(content='aaa bbb ccc',
               regions=[[(0, 4), (0, 7)]],
               in_register=['xxx\n'], params={'mode': modes.VISUAL, 'count': 1},
-              expected=('aaa \nxxx\n ccc', R(5, 5)), msg='failed in {0}'),
+              expected=('aaa xxx\n ccc', R(4, 4)), msg='failed in {0}'),
 )
 
 

--- a/xactions.py
+++ b/xactions.py
@@ -1881,33 +1881,17 @@ class _vi_big_p(ViTextCommandBase):
         text_block, linewise = self.merge(fragments)
 
         if mode == modes.INTERNAL_NORMAL:
-            if not linewise:
-                self.view.insert(edit, sel.a, text_block)
-                self.view.sel().clear()
-                pt = sel.a + len(text_block) - 1
-                self.view.sel().add(R(pt))
-            else:
-                pt = self.view.line(sel.a).a
-                self.view.insert(edit, pt, text_block)
-                self.view.sel().clear()
-                row = utils.row_at(self.view, pt)
-                pt = self.view.text_point(row, 0)
-                self.view.sel().add(R(pt))
-
+            self.view.insert(edit, sel.a, text_block)
         elif mode == modes.VISUAL:
-            if not linewise:
-                self.view.replace(edit, sel, text_block)
-            else:
-                pt = sel.a
-                if text_block[0] != '\n':
-                    text_block = '\n' + text_block
-                self.view.replace(edit, sel, text_block)
-                self.view.sel().clear()
-                row = utils.row_at(self.view, pt + len(text_block))
-                pt = self.view.text_point(row - 1, 0)
-                self.view.sel().add(R(pt))
+            self.view.replace(edit, sel, text_block)
         else:
             return
+
+        self.view.sel().clear()
+        pt = sel.a
+        if not linewise:
+            pt += len(text_block) - 1
+        self.view.sel().add(R(pt))
 
         self.enter_normal_mode(mode=mode)
 
@@ -1919,8 +1903,6 @@ class _vi_big_p(ViTextCommandBase):
         """
         block = ''.join(fragments)
         if '\n' in fragments[0]:
-            if block[-1] != '\n':
-                return (block + '\n'), True
             return block, True
         return block, False
 


### PR DESCRIPTION
This fixes #1015 and makes pasting with 'P' closer to what VIM does. Added a test case that emulates the specific case mentioned in the issue. Also, edited another test case to match the behavior I encountered in VIM. I removed a lot of code from from the _vi_big_p() function. It passes all the tests, but i apologize if I've removed some functionality not covered in the tests.