### PR TITLE
Update README.md to re-direct visitors to SublimeSix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 
 **Vintageous** is a comprehensive vi/Vim emulation layer for Sublime Text 3.
 
+Vintageous has been discontinued.
+
+The successor to Vintageous is Sublime Six.
+
+See you in Sublime Six.
+
+https://github.com/guillermooo/Six
+
+http://sublimesix.com/
+
 
 ### Installing
 


### PR DESCRIPTION
The README is one of this project's most visible sources of information and this will be the first mention it contains that Vintageous has been discontinued in favor of SublimeSix.